### PR TITLE
Fixing exit codes to indicate errors.

### DIFF
--- a/main.go
+++ b/main.go
@@ -21,10 +21,11 @@ import (
 	"os"
 	"path/filepath"
 
-	flag "github.com/spf13/pflag"
 	"k8s.io/md-check/checks"
 	"k8s.io/md-check/checks/lines"
 	"k8s.io/md-check/checks/md"
+
+	flag "github.com/spf13/pflag"
 )
 
 var (
@@ -99,10 +100,12 @@ func success() {
 	fmt.Printf(`----------------
 -- ✔ Success! --
 ----------------`)
+	os.Exit(0)
 }
 
 func fail() {
 	fmt.Printf(`-------------
 -- ✘ Fail! --
 -------------`)
+	os.Exit(1)
 }


### PR DESCRIPTION
We need the error codes to tell us if the script found errors or not, because we want it to run as a travis presubmit.

cc @Kashomon 
