### PR TITLE
Removing the whitespace check.

### DIFF
--- a/main.go
+++ b/main.go
@@ -22,7 +22,6 @@ import (
 	"path/filepath"
 
 	"k8s.io/md-check/checks"
-	"k8s.io/md-check/checks/lines"
 	"k8s.io/md-check/checks/md"
 
 	flag "github.com/spf13/pflag"
@@ -55,7 +54,6 @@ func main() {
 		Rptr:   errReporter,
 		CheckFns: []checks.CheckFunc{
 			md.ParseCheck,
-			lines.CheckWhitespace,
 		},
 	}
 


### PR DESCRIPTION
The errors being thrown are too numerous and it does not appear to be an easy fix.
The munger itself needs to be more sophisticated to see in which cases it is a valid white-space, e.g. when a sentence is split over multiple lines.

Turning it off for now so that we can run md-check against docs right away. Will turn it back on with other mungedocs mungers in the order of importance.

e.g. https://github.com/kubernetes/kubernetes.github.io/pull/1101
